### PR TITLE
Add Call type representing eth_call RPC command

### DIFF
--- a/Android/proguard-rules.pro
+++ b/Android/proguard-rules.pro
@@ -3,3 +3,30 @@
 -dontwarn org.conscrypt.**
 -dontwarn org.openjsse.javax.net.ssl.**
 -dontwarn org.openjsse.net.ssl.**
+
+# Keep `Companion` object fields of serializable classes.
+# This avoids serializer lookup through `getDeclaredClasses` as done for named companion objects.
+-if @kotlinx.serialization.Serializable class **
+-keepclassmembers class <1> {
+    static <1>$Companion Companion;
+}
+
+# Keep `serializer()` on companion objects (both default and named) of serializable classes.
+-if @kotlinx.serialization.Serializable class ** {
+    static **$* *;
+}
+-keepclassmembers class <2>$<3> {
+    kotlinx.serialization.KSerializer serializer(...);
+}
+
+# Keep `INSTANCE.serializer()` of serializable objects.
+-if @kotlinx.serialization.Serializable class ** {
+    public static ** INSTANCE;
+}
+-keepclassmembers class <1> {
+    public static <1> INSTANCE;
+    kotlinx.serialization.KSerializer serializer(...);
+}
+
+# @Serializable and @Polymorphic are used at runtime for polymorphic serialization.
+-keepattributes RuntimeVisibleAnnotations,AnnotationDefault

--- a/Apple/Wallet.xcodeproj/project.pbxproj
+++ b/Apple/Wallet.xcodeproj/project.pbxproj
@@ -306,6 +306,7 @@
 		D07F238E27595E1200E2C42C /* Wallet.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Wallet.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D07F238F27595E1500E2C42C /* Wallet.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Wallet.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D080E17327F2830F0024944D /* MainWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainWindowController.swift; sourceTree = "<group>"; };
+		D0871A932802589C003D47C4 /* WebExtension-iOS.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "WebExtension-iOS.entitlements"; sourceTree = "<group>"; };
 		D08CF09927603AF300E978CF /* Tests.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Tests.xcconfig; sourceTree = "<group>"; };
 		D0981F5226E1DEFC00CDD5CA /* Signer.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Signer.xcconfig; sourceTree = "<group>"; };
 		D0981F5626E2689000CDD5CA /* WebExtension-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "WebExtension-Info.plist"; sourceTree = "<group>"; };
@@ -535,6 +536,7 @@
 				D07C8D0E26E1C86200D4D339 /* WebExtension.xcconfig */,
 				D02D63A8272685720050BEA8 /* WebExtension-iOS.xcconfig */,
 				D02D63A7272685720050BEA8 /* WebExtension-macOS.xcconfig */,
+				D0871A932802589C003D47C4 /* WebExtension-iOS.entitlements */,
 				D0E52433272CE3C600A3370B /* WebExtension-macOS.entitlements */,
 				D0981F5626E2689000CDD5CA /* WebExtension-Info.plist */,
 				D072B10726D252A700DA1C47 /* Resources */,

--- a/Apple/WebExtension/WebExtension-iOS.entitlements
+++ b/Apple/WebExtension/WebExtension-iOS.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>$(APP_GROUP_IDENTIFIER)</string>
+	</array>
+</dict>
+</plist>

--- a/Apple/WebExtension/WebExtension-iOS.xcconfig
+++ b/Apple/WebExtension/WebExtension-iOS.xcconfig
@@ -6,3 +6,5 @@
 SDKROOT = iphoneos
 SUPPORTED_PLATFORMS = iphoneos iphonesimulator
 IPHONEOS_DEPLOYMENT_TARGET = 15.0
+
+CODE_SIGN_ENTITLEMENTS = WebExtension/WebExtension-iOS.entitlements

--- a/Shared/src/commonMain/kotlin/com/conradkramer/wallet/ethereum/BlockSpecifier.kt
+++ b/Shared/src/commonMain/kotlin/com/conradkramer/wallet/ethereum/BlockSpecifier.kt
@@ -50,7 +50,7 @@ internal sealed class BlockSpecifier {
     }
 }
 
-internal abstract class BlockSpecifierSerializer : KSerializer<BlockSpecifier> {
+internal class BlockSpecifierSerializer : KSerializer<BlockSpecifier> {
     override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("BlockSpecifier", PrimitiveKind.STRING)
 
     override fun serialize(encoder: Encoder, value: BlockSpecifier) {

--- a/Shared/src/commonMain/kotlin/com/conradkramer/wallet/ethereum/Data.kt
+++ b/Shared/src/commonMain/kotlin/com/conradkramer/wallet/ethereum/Data.kt
@@ -1,0 +1,26 @@
+package com.conradkramer.wallet.ethereum
+
+import com.conradkramer.wallet.encodeHex
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encoding.Decoder
+
+internal class DataSerializer : HexademicalValueSerializer<Data>() {
+    override fun deserialize(decoder: Decoder): Data {
+        return Data.fromString(decoder.decodeString())
+    }
+}
+
+@Serializable(with = DataSerializer::class)
+internal class Data(bytes: ByteArray) : HexademicalValue(bytes) {
+    override fun toString(): String {
+        return "0x${data.encodeHex()}"
+    }
+
+    companion object {
+        private val regex = "^0x[0-9a-f]+$".toRegex(option = RegexOption.IGNORE_CASE)
+
+        fun fromString(string: String): Data {
+            return fromString(string, false, regex, ::Data)
+        }
+    }
+}

--- a/Shared/src/commonMain/kotlin/com/conradkramer/wallet/ethereum/HexadecimalValue.kt
+++ b/Shared/src/commonMain/kotlin/com/conradkramer/wallet/ethereum/HexadecimalValue.kt
@@ -18,24 +18,11 @@ internal abstract class HexademicalValueSerializer<T : HexademicalValue> : KSeri
 internal abstract class HexademicalValue(val data: ByteArray) {
     abstract override fun toString(): String
 
-    companion object {
-        fun <T> fromString(string: String, allowNibbles: Boolean, regex: Regex, constructor: (ByteArray) -> T): T {
-            if (!regex.matches(string)) {
-                throw Exception("Address is incorrect format")
-            }
-
-            return string
-                .removePrefix("0x")
-                .decodeHex(allowNibbles)
-                .let(constructor)
-        }
-    }
-
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other == null || this::class != other::class) return false
 
-        other as Address
+        other as HexademicalValue
 
         if (!data.contentEquals(other.data)) return false
 
@@ -44,5 +31,18 @@ internal abstract class HexademicalValue(val data: ByteArray) {
 
     override fun hashCode(): Int {
         return data.contentHashCode()
+    }
+
+    companion object {
+        inline fun <reified T> fromString(string: String, allowNibbles: Boolean, regex: Regex, constructor: (ByteArray) -> T): T {
+            if (!regex.matches(string)) {
+                throw Exception("${T::class.simpleName} is incorrect format")
+            }
+
+            return string
+                .removePrefix("0x")
+                .decodeHex(allowNibbles)
+                .let(constructor)
+        }
     }
 }

--- a/Shared/src/commonMain/kotlin/com/conradkramer/wallet/ethereum/Request.kt
+++ b/Shared/src/commonMain/kotlin/com/conradkramer/wallet/ethereum/Request.kt
@@ -1,19 +1,50 @@
 package com.conradkramer.wallet.ethereum
 
+import com.conradkramer.wallet.ethereum.requests.Call
 import com.conradkramer.wallet.ethereum.requests.GetBalance
+import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.serializer
 
 internal abstract class Request<Response> {
     abstract val method: String
-    abstract val params: List<String>
+    abstract val params: List<JsonElement>
 
     fun jsonRpcRequest(id: Int): JsonRpcRequest {
         return JsonRpcRequest(method = method, params = params, id = id)
     }
 
     companion object {
-        private val mapping: Map<String, (List<String>) -> Request<*>> = mapOf(
-            ("eth_getBalance" to ::GetBalance)
+        inline fun <reified T> encode(value: T): JsonElement {
+            return Json.encodeToJsonElement(serializer(), value)
+        }
+
+        inline fun <reified T> decode(
+            params: List<JsonElement>,
+            index: Int,
+            serializer: KSerializer<T> = serializer()
+        ): T {
+            return Json.decodeFromJsonElement(serializer, params[index])
+        }
+
+        inline fun <reified T> decode(
+            params: List<JsonElement>,
+            index: Int,
+            default: T,
+            serializer: KSerializer<T> = serializer()
+        ): T {
+            return if (index < params.size) {
+                Json.decodeFromJsonElement(serializer, params[index])
+            } else {
+                default
+            }
+        }
+
+        private val mapping: Map<String, (List<JsonElement>) -> Request<*>> = mapOf(
+            ("eth_getBalance" to ::GetBalance),
+            ("eth_call" to ::Call)
         )
 
         fun fromRequest(request: JsonRpcRequest): Request<*> {
@@ -26,13 +57,23 @@ internal abstract class Request<Response> {
 }
 
 @Serializable
-internal data class JsonRpcRequest(var jsonrpc: String = "2.0", var method: String, var id: Int = 0, var params: List<String>)
+internal data class JsonRpcRequest(
+    var jsonrpc: String = "2.0",
+    var method: String,
+    var id: Int,
+    var params: List<JsonElement>
+)
 
 @Serializable
 internal data class JsonRpcError(var code: Int, var message: String)
 
 @Serializable
-internal data class JsonRpcResponse<Result>(var jsonrpc: String = "2.0", var id: Int = 0, var result: Result? = null, var error: JsonRpcError? = null)
+internal data class JsonRpcResponse<Result>(
+    var jsonrpc: String = "2.0",
+    var id: Int,
+    var result: Result? = null,
+    var error: JsonRpcError? = null
+)
 
 internal fun JsonRpcRequest.validate(response: JsonRpcResponse<*>) {
     if (this.id != response.id) {

--- a/Shared/src/commonMain/kotlin/com/conradkramer/wallet/ethereum/RpcClient.kt
+++ b/Shared/src/commonMain/kotlin/com/conradkramer/wallet/ethereum/RpcClient.kt
@@ -9,13 +9,21 @@ import io.ktor.http.ContentType
 import io.ktor.http.Url
 import io.ktor.http.contentType
 import io.ktor.serialization.kotlinx.json.json
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.json.Json
 import kotlin.random.Random
 
 internal class RpcClient(val endpointUrl: Url) {
 
+    @OptIn(ExperimentalSerializationApi::class)
     val client = HttpClient {
         install(ContentNegotiation) {
-            json()
+            json(
+                Json {
+                    encodeDefaults = true
+                    explicitNulls = false
+                }
+            )
         }
     }
 

--- a/Shared/src/commonMain/kotlin/com/conradkramer/wallet/ethereum/Transaction.kt
+++ b/Shared/src/commonMain/kotlin/com/conradkramer/wallet/ethereum/Transaction.kt
@@ -1,0 +1,14 @@
+package com.conradkramer.wallet.ethereum
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+internal data class Transaction(
+    val from: Address? = null,
+    val to: Address,
+    val gas: Quantity? = null,
+    val gasPrice: Quantity? = null,
+    val value: Quantity? = null,
+    val data: Data? = null,
+    val nonce: Quantity? = null
+)

--- a/Shared/src/commonMain/kotlin/com/conradkramer/wallet/ethereum/requests/Call.kt
+++ b/Shared/src/commonMain/kotlin/com/conradkramer/wallet/ethereum/requests/Call.kt
@@ -1,0 +1,18 @@
+package com.conradkramer.wallet.ethereum.requests
+
+import com.conradkramer.wallet.ethereum.BlockSpecifier
+import com.conradkramer.wallet.ethereum.Data
+import com.conradkramer.wallet.ethereum.Request
+import com.conradkramer.wallet.ethereum.Transaction
+import kotlinx.serialization.json.JsonElement
+
+internal data class Call(val transaction: Transaction, val specifier: BlockSpecifier = BlockSpecifier.LATEST) : Request<Data>() {
+    constructor(params: List<JsonElement>) : this(
+        decode(params, 0, Transaction.serializer()),
+        decode(params, 1, BlockSpecifier.LATEST, BlockSpecifier.serializer())
+    )
+
+    override val method: String = "eth_call"
+    override val params: List<JsonElement>
+        get() = listOf(encode(transaction), encode(specifier))
+}

--- a/Shared/src/commonMain/kotlin/com/conradkramer/wallet/ethereum/requests/GetBalance.kt
+++ b/Shared/src/commonMain/kotlin/com/conradkramer/wallet/ethereum/requests/GetBalance.kt
@@ -4,23 +4,17 @@ import com.conradkramer.wallet.ethereum.Address
 import com.conradkramer.wallet.ethereum.BlockSpecifier
 import com.conradkramer.wallet.ethereum.Quantity
 import com.conradkramer.wallet.ethereum.Request
+import kotlinx.serialization.json.JsonElement
 
-internal class GetBalance(val address: Address, val specifier: BlockSpecifier = BlockSpecifier.LATEST) : Request<Quantity>() {
-    constructor(params: List<String>) : this(Address.fromString(params[0]), optional(params, 1, BlockSpecifier.Companion::fromString, BlockSpecifier.LATEST))
+internal data class GetBalance(val address: Address, val specifier: BlockSpecifier = BlockSpecifier.LATEST) : Request<Quantity>() {
+    constructor(params: List<JsonElement>) : this(
+        decode(params, 0, Address.serializer()),
+        decode(params, 1, BlockSpecifier.LATEST, BlockSpecifier.serializer())
+    )
 
     override val method: String = "eth_getBalance"
-    override val params: List<String>
-        get() = listOf(address.toString(), specifier.encoded)
-
-    companion object {
-        fun <R> optional(params: List<String>, index: Int, constructor: (String) -> R, default: R): R {
-            return if (index < params.size) {
-                constructor(params[index])
-            } else {
-                default
-            }
-        }
-    }
+    override val params: List<JsonElement>
+        get() = listOf(encode(address), encode(specifier))
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/Shared/src/commonTest/kotlin/com/conradkramer/wallet/ethereum/requests/CallTests.kt
+++ b/Shared/src/commonTest/kotlin/com/conradkramer/wallet/ethereum/requests/CallTests.kt
@@ -1,0 +1,21 @@
+package com.conradkramer.wallet.ethereum.requests
+
+import com.conradkramer.wallet.ethereum.Address
+import com.conradkramer.wallet.ethereum.Data
+import com.conradkramer.wallet.ethereum.JsonRpcRequest
+import com.conradkramer.wallet.ethereum.Request
+import com.conradkramer.wallet.ethereum.Transaction
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class CallTests {
+    @Test
+    fun testSerialization() {
+        val request = Call(Transaction(to = Address.fromString("0x8A6752a88417e8F7D822DaCaeB52Ed8e6e591c43"), data = Data(ByteArray(5))))
+        val jsonRpcRequest = Json.decodeFromString<JsonRpcRequest>("""{"method":"eth_call", "id": 2, "params": [{"to": "0x8A6752a88417e8F7D822DaCaeB52Ed8e6e591c43", "data": "0x0000000000"}, "latest"], "jsonrpc": "2.0"}""")
+        val deserialized = Request.fromRequest(jsonRpcRequest)
+        assertEquals(request, deserialized)
+    }
+}


### PR DESCRIPTION
In order to do this, I had to update Request to use JsonElement for
params instead of String because eth_call and eth_sendTransaction send
objects as parameters, not strings.