### PR TITLE
Fix XCResult bundle uploading when running macOS tests

### DIFF
--- a/.github/actions/test-without-building/action.yml
+++ b/.github/actions/test-without-building/action.yml
@@ -9,8 +9,8 @@ inputs:
   test-plan:
     description: Test Plan
     required: false
-  artifact-name:
-    description: The name to give the uploaded xcresults file
+  artifact-prefix:
+    description: The prefix for the filename of the uploaded xcresults file
     required: true
   check-name:
     description: The check name
@@ -19,27 +19,19 @@ runs:
   using: composite
   steps:
   - shell: bash
+    id: vars
+    run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+  - shell: bash
     working-directory: Apple
     run: |
       xcodebuild test-without-building \
       -scheme '${{ inputs.scheme }}' \
       -destination '${{ inputs.destination }}' \
       ${{ inputs.test-plan && '-testPlan ' }}${{ inputs.test-plan }} \
-      -resultBundlePath TestResults.xcresult
-
-      zip TestResults.xcresult.zip TestResults.xcresult
-  - uses: actions/upload-artifact@v3
-    if: always()
-    with:
-      name: ${{ inputs.artifact-name }}
-      path: Apple/TestResults.xcresult.zip
+      -resultBundlePath "${{ inputs.artifact-prefix }}-${{ steps.vars.outputs.sha_short }}.xcresult"
   - uses: kishikawakatsumi/xcresulttool@v1
     if: always()
     with:
-      path: Apple/TestResults.xcresult
+      path: Apple/${{ inputs.artifact-prefix }}-${{ steps.vars.outputs.sha_short }}.xcresult
       title: ${{ inputs.check-name }}
       show-passed-tests: false
-  - shell: bash
-    if: always()
-    working-directory: Apple
-    run: rm -rf TestResults.xcresult.zip TestResults.xcresult

--- a/.github/workflows/build-apple.yml
+++ b/.github/workflows/build-apple.yml
@@ -23,15 +23,18 @@ jobs:
         - scheme: App (iOS)
           destination: generic/platform=iOS
           platform: iOS
+          sdk-name: iphoneos
         - scheme: App (iOS)
           destination: platform=iOS Simulator,OS=15.2,name=iPhone 13 Pro
           platform: iOS Simulator
+          sdk-name: iphonesimulator
           xcode-unit-test: UnitTests
           xcode-ui-test: UITests-iOS
           gradle-test: iosX64Test
         - scheme: App (macOS)
           destination: platform=macOS
           platform: macOS
+          sdk-name: macos
           xcode-unit-test: UnitTests
           gradle-test: macosX64Test
     env:
@@ -74,7 +77,7 @@ jobs:
         scheme: ${{ matrix.configuration['scheme'] }}
         destination: ${{ matrix.configuration['destination'] }}
         test-plan: ${{ matrix.configuration['xcode-unit-test'] }}
-        artifact-name: ${{ matrix.configuration['xcode-unit-test'] }}-${{ matrix.configuration['platform'] }}
+        artifact-prefix: unit-tests-${{ matrix.configuration['sdk-name'] }}
         check-name: Xcode Unit Tests (${{ matrix.configuration['platform'] }})
     - name: Kotlin Unit Test
       if: ${{ matrix.configuration['gradle-test'] != '' }}
@@ -91,5 +94,5 @@ jobs:
         scheme: ${{ matrix.configuration['scheme'] }}
         destination: ${{ matrix.configuration['destination'] }}
         test-plan: ${{ matrix.configuration['xcode-ui-test'] }}
-        artifact-name: ${{ matrix.configuration['xcode-ui-test'] }}-${{ matrix.configuration['platform'] }}
+        artifact-prefix: ui-tests-${{ matrix.configuration['sdk-name'] }}
         check-name: Xcode UI Tests (${{ matrix.configuration['platform'] }})


### PR DESCRIPTION
This prevents xcresulttool uploads from conflicting, and removes the
custom artifact uploading code