### PR TITLE
Fix Android Message serialization tests

### DIFF
--- a/Shared/src/commonMain/kotlin/com/conradkramer/wallet/browser/event/Event.kt
+++ b/Shared/src/commonMain/kotlin/com/conradkramer/wallet/browser/event/Event.kt
@@ -20,11 +20,13 @@ internal abstract class Event {
         }
 
         @OptIn(ExperimentalSerializationApi::class)
-        val json = Json {
-            encodeDefaults = true
-            explicitNulls = false
-            serializersModule = SerializersModule {
-                include(serializersModuleOf(Quantity.serializer()))
+        val json by lazy {
+            Json {
+                encodeDefaults = true
+                explicitNulls = false
+                serializersModule = SerializersModule {
+                    include(serializersModuleOf(Quantity.serializer()))
+                }
             }
         }
     }

--- a/Shared/src/commonMain/kotlin/com/conradkramer/wallet/browser/message/Message.kt
+++ b/Shared/src/commonMain/kotlin/com/conradkramer/wallet/browser/message/Message.kt
@@ -46,14 +46,16 @@ internal sealed class Message {
             }
         }
 
-        private val json = Json {
-            serializersModule = SerializersModule {
-                polymorphic(Message::class, serializer()) {
-                    subclass(EventMessage.serializer())
-                    subclass(OpenURLMessage.serializer())
-                    subclass(RPCRequestMessage.serializer())
-                    subclass(RPCResponseMessage.serializer())
-                    subclass(StartSessionMessage.serializer())
+        private val json by lazy {
+            Json {
+                serializersModule = SerializersModule {
+                    polymorphic(Message::class) {
+                        subclass(EventMessage.serializer())
+                        subclass(OpenURLMessage.serializer())
+                        subclass(RPCRequestMessage.serializer())
+                        subclass(RPCResponseMessage.serializer())
+                        subclass(StartSessionMessage.serializer())
+                    }
                 }
             }
         }


### PR DESCRIPTION
Make the json properties lazy, so that the entire runtime is initialized before the json module is.